### PR TITLE
Remove redundant parameter

### DIFF
--- a/01-discordjs/bot.js
+++ b/01-discordjs/bot.js
@@ -17,8 +17,8 @@ client.once(Events.ClientReady, readyDiscord);
 // Login to Discord with your client's token
 client.login(process.env.TOKEN);
 
-function readyDiscord(c) {
-  console.log('💖 Logged in as', c.user.tag);
+function readyDiscord() {
+  console.log('💖 Logged in as', client.user.tag);
 }
 
 client.on('interactionCreate', async (interaction) => {


### PR DESCRIPTION
The c variable in the readyDiscord function is not required as we already have a reference to the Discord client instance in the global scope. This can as a result be replaced with the client variable instead. Additionally this has the side effect of fixing [this issue comment](https://github.com/Programming-from-A-to-Z/Discord-Bot-Examples/pull/6#discussion_r1351128507) because the variable is no longer there.