### PR TITLE
Update dotenv import to just import the config function

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ Create `bot.js` (or `index.js`) and paste this code:
 
 ```javascript
 import { Client, Events, GatewayIntentBits } from 'discord.js';
-import dotenv from 'dotenv';
+import { config } from 'dotenv';
 
-dotenv.config();
+config();
 
 // Create a new client instance
 const client = new Client({


### PR DESCRIPTION
In this section of the example code: https://github.com/Programming-from-A-to-Z/Discord-Bot-Examples/blob/ac8ee1ebf1a3199c302f8ee38f6fc177998df08f/01-discordjs/deploy-commands.js#L6-L9
we are only importing the config function and calling it from dotenv. To keep consistent through the code, I replaced this in the readme as well.